### PR TITLE
Fix Zoxide Initialization in .zshrc

### DIFF
--- a/roles/archlinux/tasks/zsh.yml
+++ b/roles/archlinux/tasks/zsh.yml
@@ -74,6 +74,12 @@
     state: present
     line: 'source <(fzf --zsh)'
 
+- name: Configure Zsh to source zoxide
+  ansible.builtin.lineinfile:
+    path: /home/{{ ansible_user_id }}/.zshrc
+    state: present
+    line: 'eval "$(zoxide init zsh)"'
+
 - name: Export EDITOR variable to zsh 
   ansible.builtin.lineinfile:
     path: /home/{{ ansible_user_id }}/.zshrc


### PR DESCRIPTION
This pull request fixes a bug where Zoxide was not being properly initialized in the .zshrc file, despite being installed. The change adds the following line:

```bash
eval "$(zoxide init zsh)"
```

to ensure that Zoxide is sourced correctly whenever a new Zsh session is started. For more details on this configuration, refer to the [Zoxide documentation for Zsh](https://github.com/ajeetdsouza/zoxide#:~:text=Add%20this%20to%20the%20end%20of%20your%20config%20file%20(usually%20~/.zshrc,eval%20%22%24(zoxide%20init%20zsh)%22).

This adjustment resolves the initialization issue, allowing for proper directory tracking and navigation.